### PR TITLE
Enable custom parameters on a custom connector

### DIFF
--- a/scripts/modules/MsIndustryLinks/templates/data_source/DataSourceWorkflow.psm1
+++ b/scripts/modules/MsIndustryLinks/templates/data_source/DataSourceWorkflow.psm1
@@ -181,6 +181,11 @@ function New-FlowCustomConnectorDatasourceWorkflow {
     # Update the connector operation ID
     $definition.actions.Retrieve_data_using_custom_connector.inputs.host.operationId = $parameters.connectorOperationId.value
 
+    # Add the custom connector parameters if they exist
+    if ($parameters.PSobject.Properties.name -match "customConnectorParameters") {
+        $definition.actions.Retrieve_data_using_custom_connector.inputs.parameters = $parameters.customConnectorParameters.value
+    }
+
     # Update Dataverse ingestion sub-workflow configuration
     $definition.actions.Ingest_data_subflow.inputs.host.workflowReferenceName = $IngestionWorkflowGuid
 

--- a/scripts/modules/MsIndustryLinks/templates/data_source/customconnector/customconnectors.parameters.json.tmpl
+++ b/scripts/modules/MsIndustryLinks/templates/data_source/customconnector/customconnectors.parameters.json.tmpl
@@ -13,6 +13,14 @@
     "value": false
   },
 
+  ///--- CUSTOM CONNECTORS WITH PARAMETERS ONLY ---///
+  "customConnectorParameters": {
+    "value": {
+      "parameter1": "",
+      "parameter2": ""
+    }
+  }
+
   ///--- CERTIFIED CUSTOM CONNECTORS ONLY ---///
 
   // The custom connector API name


### PR DESCRIPTION
Update the custom connector data source parameters file to include customisable parameters to the custom connector.

The custom connector generation script requires no changes as the API definition is what drives the custom connectors parameters. This is supplied by the Industry Link creator.