### PR TITLE
Add cmdlet to generate ARM templates for Logic App industry link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ target/
 **/*/clientConfig.json
 **/output/*
 **/*/parameters.json
+MsIndustryLinks.psm1
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/scripts/modules/MsIndustryLinks/README.md
+++ b/scripts/modules/MsIndustryLinks/README.md
@@ -10,14 +10,15 @@ The **MsIndustryLinks** module contains cmdlets to generate workflow templates (
 
 ## MsIndustryLinks
 
-|                                                                            |                                                                    |
-| -------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| [New-AppSourceOffer](appsource/New-AppSourceOffer.md)                      | Create an AppSource offer in Partner Center                        |
-| [New-AppSourcePackage](appsource/New-AppSourcePackage.md)                  | Create an AppSource package from managed solution                  |
-| [New-CustomConnector](customConnector/New-CustomConnector.md)              | Create a custom connector in a Power Platform environment          |
-| [New-CustomConnectorConfig](customConnector/New-CustomConnectorConfig.md)  | Creates Power Platform custom connector asset configuration files  |
-| [New-DataSourceWorkflow](templates/data_source/New-DataSourceWorkflow.md)  | Generate an end-to-end workflow template for specified data source |
-| [New-IngestionWorkflow](templates/ingest/New-IngestionWorkflow.md)         | Generate an ingestion workflow template                            |
-| [New-MsIndustryLink](templates/New-MsIndustryLink.md)                      | Generate a Microsoft Industry Link                                 |
-| [New-TransformWorkflow](templates/data_transform/New-TransformWorkflow.md) | Generate a transform workflow template                             |
-| [New-WorkflowPackage](templates/package/New-WorkflowPackage.md)            | Package workflow templates into a solution                         |
+|                                                                                    |                                                                                       |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| [New-AppSourceOffer](appsource/New-AppSourceOffer.md)                              | Create an AppSource offer in Partner Center                                           |
+| [New-AppSourcePackage](appsource/New-AppSourcePackage.md)                          | Create an AppSource package from managed solution                                     |
+| [New-AzureDeploymentPackage](azureDeploymentPackage/New-AzureDeploymentPackage.md) | Generate ARM templates that deploys the Azure resources required for an Industry Link |
+| [New-CustomConnector](customConnector/New-CustomConnector.md)                      | Create a custom connector in a Power Platform environment                             |
+| [New-CustomConnectorConfig](customConnector/New-CustomConnectorConfig.md)          | Creates Power Platform custom connector asset configuration files                     |
+| [New-DataSourceWorkflow](templates/data_source/New-DataSourceWorkflow.md)          | Generate an end-to-end workflow template for specified data source                    |
+| [New-IngestionWorkflow](templates/ingest/New-IngestionWorkflow.md)                 | Generate an ingestion workflow template                                               |
+| [New-MsIndustryLink](templates/New-MsIndustryLink.md)                              | Generate a Microsoft Industry Link                                                    |
+| [New-TransformWorkflow](templates/data_transform/New-TransformWorkflow.md)         | Generate a transform workflow template                                                |
+| [New-WorkflowPackage](templates/package/New-WorkflowPackage.md)                    | Package workflow templates into a solution                                            |

--- a/scripts/modules/MsIndustryLinks/azureDeploymentPackage/AzureDeploymentPackage.psm1
+++ b/scripts/modules/MsIndustryLinks/azureDeploymentPackage/AzureDeploymentPackage.psm1
@@ -1,0 +1,317 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+    .Synopsis
+    Generates ARM templates that deploys the Azure resources
+    required for an Industry Link.
+
+    .Description
+    Generates ARM templates that deploys the Azure resources such
+    as storage account, event hub, connections and Logic Apps
+    required for an Industry Link.
+
+    .Parameter WorkflowConfigFile
+    The workflow configuration file that defines the trigger, the data
+    source, the data sink and any transformations that will be applied.
+
+    .Parameter TemplateDirectory
+    The path to the workflow templates required for your Industry Link. This
+    should contain at least one workflow template.
+
+    .Parameter OutputDirectory
+    The directory path where the ARM templates will be saved.
+
+    .Example
+    # Generate ARM templates from Logic App workflow templates
+    New-AzureDeploymentPackage -WorkflowConfigFile workflow.json -TemplateDirectory templates -OutputDirectory output
+#>
+function New-AzureDeploymentPackage {
+    param (
+        [Parameter(Mandatory = $true, HelpMessage = "The path to the workflow configuration JSON file.")]
+        [string] $WorkflowConfigFile,
+        [Parameter(Mandatory = $true, HelpMessage = "The path to the directory containing the workflow templates.")]
+        [string] $TemplateDirectory,
+        [Parameter(Mandatory = $true, HelpMessage = "The directory path where the ARM templates will be saved.")]
+        [string] $OutputDirectory
+    )
+
+    $workflowConfig = Get-Content $WorkflowConfigFile | ConvertFrom-Json
+    $workflowName = $workflowConfig.name
+
+    if (!(Test-Path $OutputDirectory)) {
+        New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+    }
+
+    # Parent Logic App template dependencies
+    $dependencies = @(
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('managedIdentityName'))]"
+    )
+
+    $mainTemplate = Get-Content "$PSScriptRoot/azureDeploymentPackage/azuredeploy.json" | ConvertFrom-Json
+    $mainTemplate.variables.managedIdentityName = "$($workflowName)User"
+
+    # Generate ARM templates for data sink workflow
+    $sinkDeploymentName = "$($workflowName)_Sink"
+    New-ResourceTemplate -WorkflowName $workflowName -MainTemplate $mainTemplate -SubWorkflowConfig $workflowConfig.dataSink -OutputDirectory $OutputDirectory
+    New-LogicAppTemplate -Name $sinkDeploymentName -Dependencies $dependencies -MainTemplate $mainTemplate -SubWorkflowConfig $workflowConfig.dataSink -TemplateDirectory $TemplateDirectory -OutputDirectory $OutputDirectory
+
+    # Generate ARM templates for data transform workflow
+    if ($null -ne $workflowConfig.dataTransform.type) {
+        $transformDeploymentName = "$($workflowName)_Transform"
+        New-LogicAppTemplate -Name $transformDeploymentName -Dependencies $dependencies -MainTemplate $mainTemplate -SubWorkflowConfig @{ type = "" } -TemplateDirectory $TemplateDirectory -OutputDirectory $OutputDirectory
+        $dependencies += "[resourceId('Microsoft.Resources/deployments', '$transformDeploymentName')]"
+    }
+
+    # Generate ARM templates for data source workflow
+    $dependencies += "[resourceId('Microsoft.Resources/deployments', '$sinkDeploymentName')]"
+    New-ResourceTemplate -WorkflowName $workflowName -MainTemplate $mainTemplate -SubWorkflowConfig $workflowConfig.dataSource -OutputDirectory $OutputDirectory
+    New-LogicAppTemplate -Name $workflowName -Dependencies $dependencies -MainTemplate $mainTemplate -SubWorkflowConfig $workflowConfig.dataSource -TemplateDirectory $TemplateDirectory -OutputDirectory $OutputDirectory
+
+    # Generate main ARM template
+    $mainTemplate | ConvertTo-Json -Depth 100 | Out-File "$OutputDirectory/azuredeploy.json"
+}
+
+function New-ResourceTemplate {
+    param (
+        [Parameter(Mandatory = $true, HelpMessage = "The name of the workflow.")]
+        [string] $WorkflowName,
+        [Parameter(Mandatory = $true, HelpMessage = "The main ARM template object.")]
+        [object] $MainTemplate,
+        [Parameter(Mandatory = $true, HelpMessage = "The configuration object of the sub-workflow (source, sink, transform).")]
+        [object] $SubWorkflowConfig,
+        [Parameter(Mandatory = $true, HelpMessage = "The directory path where the ARM templates will be saved.")]
+        [string] $OutputDirectory
+    )
+
+    switch ($SubWorkflowConfig.type.ToLower()) {
+        "azureblobstorage" {
+            New-BlobStorageTemplate -MainTemplate $MainTemplate -Parameters $SubWorkflowConfig.parameters -OutputDirectory $OutputDirectory
+            break
+        }
+        "dataverse" {
+            New-DataverseTemplates -MainTemplate $MainTemplate -OutputDirectory $OutputDirectory
+            break
+        }
+        "eventhub" {
+            New-EventHubTemplates -WorkflowName $WorkflowName -MainTemplate $MainTemplate -Parameters $SubWorkflowConfig.parameters -OutputDirectory $OutputDirectory
+            break
+        }
+        Default {
+            throw "Sub-workflow type, $($SubWorkflowConfig.type), not supported."
+        }
+    }
+}
+
+function New-BlobStorageTemplate {
+    param (
+        [Parameter(Mandatory = $true, HelpMessage = "The main ARM template object.")]
+        [object] $MainTemplate,
+        [Parameter(Mandatory = $true, HelpMessage = "The sub-workflow parameters.")]
+        [object] $Parameters,
+        [Parameter(Mandatory = $true, HelpMessage = "The directory path where the ARM templates will be saved.")]
+        [string] $OutputDirectory
+    )
+
+    try {
+        $deployTemplate = Get-Content "$PSScriptRoot/azureDeploymentPackage/azureblobstorage/deploy.json" | ConvertFrom-Json
+        $deployTemplate.variables.storageAccountName = $Parameters.storage_account_name.value
+        $deployTemplate.variables.containerName = $Parameters.storage_container_name.value
+        $deployTemplate | ConvertTo-Json -Depth 100 | Out-File "$OutputDirectory/deploy.azureBlobStorage.json"
+    }
+    catch {
+        throw "Failed to generate deployment template for Azure Blob Storage."
+    }
+
+    try {
+        $deployDependencies = @(
+            "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('managedIdentityName'))]"
+        )
+        $deployLinkedTemplate = Get-LinkedTemplate -Name "azureblobstorage" -FileName "deploy.azureBlobStorage.json" -Dependencies $deployDependencies
+        $deployLinkedTemplate.properties.parameters.managedIdentityName = @{
+            value = "[variables('managedIdentityName')]"
+        }
+        $MainTemplate.resources += $deployLinkedTemplate
+    }
+    catch {
+        throw "Failed to add linked template for Azure Blob Storage resource."
+    }
+
+    try {
+        $connectionDependencies = @(
+            "[resourceId('Microsoft.Resources/deployments', 'azureblobstorage')]"
+        )
+        Copy-Item "$PSScriptRoot/azureDeploymentPackage/azureblobstorage/connection.json" "$OutputDirectory/connection.azureBlobStorage.json"
+        $MainTemplate.resources += Get-LinkedTemplate -Name "azureblobstorageconnection" -FileName "connection.azureBlobStorage.json" -Dependencies $connectionDependencies
+    }
+    catch {
+        throw "Failed to add linked template for Azure Blob Storage connection."
+    }
+}
+
+function New-DataverseTemplates {
+    param (
+        [Parameter(Mandatory = $true, HelpMessage = "The main ARM template object.")]
+        [object] $MainTemplate,
+        [Parameter(Mandatory = $true, HelpMessage = "The directory path where the ARM templates will be saved.")]
+        [string] $OutputDirectory
+    )
+
+    try {
+        $linkedTemplate = Get-LinkedTemplate -Name "dataverseconnection" -FileName "connection.dataverse.json"
+        $connectionTemplate = Get-Content "$PSScriptRoot/azureDeploymentPackage/dataverse/connection.json" | ConvertFrom-Json
+
+        foreach ($param in @("tenantId", "clientId", "clientSecret")) {
+            $linkedTemplate.properties.parameters.$param = @{
+                value = "[parameters('$param')]"
+            }
+
+            $MainTemplate.parameters | Add-Member -MemberType NoteProperty -Name $param -Value $connectionTemplate.parameters.$param
+        }
+        $MainTemplate.resources += $linkedTemplate
+
+        Copy-Item "$PSScriptRoot/azureDeploymentPackage/dataverse/connection.json" "$OutputDirectory/connection.dataverse.json"
+    }
+    catch {
+        throw "Failed to add linked template for Dataverse connection."
+    }
+}
+
+function New-EventHubTemplates {
+    param (
+        [Parameter(Mandatory = $true, HelpMessage = "The name of the workflow.")]
+        [string] $WorkflowName,
+        [Parameter(Mandatory = $true, HelpMessage = "The main ARM template object.")]
+        [object] $MainTemplate,
+        [Parameter(Mandatory = $true, HelpMessage = "The sub-workflow parameters.")]
+        [object] $Parameters,
+        [Parameter(Mandatory = $true, HelpMessage = "The directory path where the ARM templates will be saved.")]
+        [string] $OutputDirectory
+    )
+
+    try {
+        $deployTemplate = Get-Content "$PSScriptRoot/azureDeploymentPackage/eventhub/deploy.json" | ConvertFrom-Json
+        $deployTemplate.variables.eventHubNamespaceName = "$($WorkflowName)eh".ToLower()
+        $deployTemplate.variables.eventHubName = $Parameters.event_hub_name.value
+        $deployTemplate.variables.consumerGroupName = $Parameters.event_hub_parameters.value.consumerGroupName
+        $deployTemplate | ConvertTo-Json -Depth 100 | Out-File "$OutputDirectory/deploy.eventHub.json"
+    }
+    catch {
+        throw "Failed to generate deployment template for Event Hub."
+    }
+
+    try {
+        $deployDependencies = @(
+            "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('managedIdentityName'))]"
+        )
+        $linkedTemplate = Get-LinkedTemplate -Name "eventhub" -FileName "deploy.eventHub.json" -Dependencies $deployDependencies
+        $linkedTemplate.properties.parameters.managedIdentityName = @{
+            value = "[variables('managedIdentityName')]"
+        }
+        $MainTemplate.resources += $linkedTemplate
+    }
+    catch {
+        throw "Failed to add linked template for Event Hub resource."
+    }
+
+    try {
+        $connectionDependencies = @(
+            "[resourceId('Microsoft.Resources/deployments', 'eventhub')]"
+        )
+        $connectionTemplate = Get-Content "$PSScriptRoot/azureDeploymentPackage/eventhub/connection.json" | ConvertFrom-Json
+        $connectionTemplate.variables.eventHubNamespaceName = "$($WorkflowName)eh".ToLower()
+        $connectionTemplate | ConvertTo-Json -Depth 100 | Out-File "$OutputDirectory/connection.eventHub.json"
+        $MainTemplate.resources += Get-LinkedTemplate -Name "eventhubconnection" -FileName "connection.eventHub.json" -Dependencies $connectionDependencies
+    }
+    catch {
+        throw "Failed to add linked template for Event Hub connection."
+    }
+}
+
+function New-LogicAppTemplate {
+    param (
+        [Parameter(Mandatory = $true, HelpMessage = "The name of the sub-workflow.")]
+        [string] $Name,
+        [Parameter(Mandatory = $true, HelpMessage = "The list of dependencies for the Logic App ARM template.")]
+        [array] $Dependencies,
+        [Parameter(Mandatory = $true, HelpMessage = "The main ARM template object.")]
+        [object] $MainTemplate,
+        [Parameter(Mandatory = $true, HelpMessage = "The configuration object of the sub-workflow (source, sink, transform).")]
+        [object] $SubWorkflowConfig,
+        [Parameter(Mandatory = $true, HelpMessage = "The path to the directory containing the workflow templates.")]
+        [string] $TemplateDirectory,
+        [Parameter(Mandatory = $true, HelpMessage = "The directory path where the ARM templates will be saved.")]
+        [string] $OutputDirectory
+    )
+
+    try {
+        $logicAppTemplatePath = Join-Path $TemplateDirectory "$Name.json"
+        $deployTemplate = Get-Content "$PSScriptRoot/azureDeploymentPackage/logicApp/deploy.json" | ConvertFrom-Json
+        $resourceType = $SubWorkflowConfig.type.ToLower()
+
+        if ("" -ne $resourceType) {
+            $Dependencies += "[resourceId('Microsoft.Resources/deployments', '$($resourceType)connection')]"
+        }
+        $linkedTemplate = Get-LinkedTemplate -Name $Name -FileName "deploy.$Name.json" -Dependencies $Dependencies
+
+        if ($resourceType -eq "dataverse") {
+            $orgUrlParam = @{
+                type     = "string"
+                metadata = @{
+                    description = "Azure AD authentication tenant ID."
+                }
+            }
+
+            $deployTemplate.parameters | Add-Member -MemberType NoteProperty -Name "organizationUrl" -Value $orgUrlParam
+            $MainTemplate.parameters | Add-Member -MemberType NoteProperty -Name "organizationUrl" -Value $orgUrlParam
+
+            $linkedTemplate.properties.parameters.organizationUrl = @{
+                value = "[parameters('organizationUrl')]"
+            }
+        }
+
+        $deployTemplate.variables.name = $Name
+        $deployTemplate.resources[0].properties = Get-Content $logicAppTemplatePath | ConvertFrom-Json
+        $deployTemplate | ConvertTo-Json -Depth 100 | Out-File "$OutputDirectory/deploy.$Name.json"
+
+        $linkedTemplate.properties.parameters.managedIdentityName = @{
+            value = "[variables('managedIdentityName')]"
+        }
+        $MainTemplate.resources += $linkedTemplate
+    }
+    catch {
+        throw "Failed to generate deployment template for Logic App."
+    }
+}
+
+function Get-LinkedTemplate {
+    param (
+        [Parameter(Mandatory = $true, HelpMessage = "The name of the linked template.")]
+        [string] $Name,
+        [Parameter(Mandatory = $true, HelpMessage = "The name of the file for this linked template.")]
+        [string] $FileName,
+        [Parameter(Mandatory = $false, HelpMessage = "The list of dependencies for this linked template.")]
+        [array] $Dependencies = @()
+    )
+
+    return @{
+        type       = "Microsoft.Resources/deployments"
+        apiVersion = "2021-04-01"
+        name       = $Name
+        properties = @{
+            mode         = "Incremental"
+            templateLink = @{
+                uri            = "[concat(parameters('_artifactsLocation'), '$FileName', parameters('_artifactsLocationSasToken'))]"
+                contentVersion = "1.0.0.0"
+            }
+            parameters   = @{
+                location = @{
+                    value = "[parameters('location')]"
+                }
+            }
+        }
+        dependsOn  = $Dependencies
+    }
+}
+
+Export-ModuleMember -Function New-AzureDeploymentPackage

--- a/scripts/modules/MsIndustryLinks/azureDeploymentPackage/New-AzureDeploymentPackage.md
+++ b/scripts/modules/MsIndustryLinks/azureDeploymentPackage/New-AzureDeploymentPackage.md
@@ -1,0 +1,70 @@
+# New-AzureDeploymentPackage
+
+Module: [MsIndustryLinks](../README.md)
+
+Generates ARM templates that deploys the Azure resources required for an Industry Link.
+
+## Syntax
+
+```powershell
+New-AzureDeploymentPackage
+    -WorkflowConfigFile <String>
+    -TemplateDirectory <String>
+    -OutputDirectory <String>
+```
+
+## Description
+
+Generates ARM templates that deploys the Azure resources such as storage account, event hub, connections and Logic Apps required for an Industry Link.
+
+## Examples
+
+### Example 1: Generate ARM templates from Logic App workflow templates
+
+```powershell
+New-AzureDeploymentPackage
+    -WorkflowConfigFile workflow.json
+    -TemplateDirectory templates
+    -OutputDirectory output
+```
+
+## Parameters
+
+### -WorkflowConfigFile
+
+The workflow configuration file that defines the trigger, the data source, the data sink and any transformations that will be applied. See [logicapp_workflow.json.tmpl](../templates/logicapp_workflow.json.tmpl) for an example of the workflow configuration file.
+
+|                |                                                                                                                       |
+| -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Type:          | [String](https://learn.microsoft.com/en-us/powershell/scripting/lang-spec/chapter-04?view=powershell-7.3#431-strings) |
+| Default value: | None                                                                                                                  |
+
+### -TemplateDirectory
+
+The path to the workflow templates required for your Industry Link. This should contain at least one workflow template.
+
+|                |                                                                                                                       |
+| -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Type:          | [String](https://learn.microsoft.com/en-us/powershell/scripting/lang-spec/chapter-04?view=powershell-7.3#431-strings) |
+| Default value: | None                                                                                                                  |
+
+### -OutputDirectory
+
+The directory path where the ARM templates will be saved.
+
+|                |                                                                                                                       |
+| -------------- | --------------------------------------------------------------------------------------------------------------------- |
+| Type:          | [String](https://learn.microsoft.com/en-us/powershell/scripting/lang-spec/chapter-04?view=powershell-7.3#431-strings) |
+| Default value: | None                                                                                                                  |
+
+## Inputs
+
+**None**
+
+This cmdlet accepts no input.
+
+## Outputs
+
+**None**
+
+This cmdlet returns no output.

--- a/scripts/modules/MsIndustryLinks/azureDeploymentPackage/azureblobstorage/connection.json
+++ b/scripts/modules/MsIndustryLinks/azureDeploymentPackage/azureblobstorage/connection.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Specifies the location in which the resources should be deployed."
+      }
+    }
+  },
+  "variables": {
+    "name": "azureblob",
+    "displayName": "Azure Blob Storage Connection"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/connections",
+      "apiVersion": "2016-06-01",
+      "name": "[variables('name')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "displayName": "[variables('displayName')]",
+        "api": {
+          "id": "[subscriptionResourceId('Microsoft.Web/locations/managedApis', parameters('location'), 'azureblob')]"
+        },
+        "parameterValueSet": {
+          "name": "managedIdentityAuth"
+        }
+      }
+    }
+  ]
+}

--- a/scripts/modules/MsIndustryLinks/azureDeploymentPackage/azureblobstorage/deploy.json
+++ b/scripts/modules/MsIndustryLinks/azureDeploymentPackage/azureblobstorage/deploy.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Specifies the location in which the resources should be deployed."
+      }
+    },
+    "managedIdentityName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the user managed identity to assign to this resource."
+      }
+    }
+  },
+  "variables": {
+    "storageAccountName": "contosoindustrylinksa",
+    "containerName": "data",
+    "roleDefinitionId": "ba92f5b4-2d11-453d-a403-e96b0029c9fe",
+    "roleAssignmentDescription": "Contoso Industry Link blob storage access"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Storage/storageAccounts",
+      "apiVersion": "2022-05-01",
+      "name": "[variables('storageAccountName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "Standard_LRS"
+      },
+      "kind": "StorageV2",
+      "properties": {
+        "accessTier": "Hot"
+      }
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices",
+      "apiVersion": "2019-06-01",
+      "name": "[format('{0}/{1}', variables('storageAccountName'), 'default')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+      "apiVersion": "2022-05-01",
+      "name": "[format('{0}/{1}/{2}', variables('storageAccountName'), 'default', variables('containerName'))]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Storage/storageAccounts/blobServices', variables('storageAccountName'), 'default')]"
+      ]
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-04-01-preview",
+      "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), resourceGroup().id, variables('roleDefinitionId'))]",
+      "properties": {
+        "description": "[variables('roleAssignmentDescription')]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), '2018-11-30').principalId]",
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefinitionId'))]",
+        "principalType": "ServicePrincipal"
+      }
+    }
+  ]
+}

--- a/scripts/modules/MsIndustryLinks/azureDeploymentPackage/azuredeploy.json
+++ b/scripts/modules/MsIndustryLinks/azureDeploymentPackage/azuredeploy.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Specifies the location in which the resources should be deployed."
+      }
+    },
+    "_artifactsLocation": {
+      "type": "string",
+      "defaultValue": "[deployment().properties.templateLink.uri]",
+      "metadata": {
+        "description": "The base URI where artifacts required by this template are located including a trailing '/'"
+      }
+    },
+    "_artifactsLocationSasToken": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The sasToken required to access _artifactsLocation."
+      }
+    }
+  },
+  "variables": {
+    "managedIdentityName": "ContosoIndustryLinkUser"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2018-11-30",
+      "name": "[variables('managedIdentityName')]",
+      "location": "[parameters('location')]"
+    }
+  ]
+}

--- a/scripts/modules/MsIndustryLinks/azureDeploymentPackage/dataverse/connection.json
+++ b/scripts/modules/MsIndustryLinks/azureDeploymentPackage/dataverse/connection.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Specifies the location in which the resources should be deployed."
+      }
+    },
+    "tenantId": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure AD authentication tenant ID."
+      }
+    },
+    "clientId": {
+      "type": "string",
+      "metadata": {
+        "description": "Azure AD authentication client ID."
+      }
+    },
+    "clientSecret": {
+      "type": "securestring",
+      "metadata": {
+        "description": "Azure AD authentication client secret."
+      }
+    }
+  },
+  "variables": {
+    "grantType": "client_credentials",
+    "name": "commondataservice",
+    "displayName": "Dataverse Connection"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/connections",
+      "apiVersion": "2016-06-01",
+      "name": "[variables('name')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "displayName": "[variables('displayName')]",
+        "api": {
+          "id": "[subscriptionResourceId('Microsoft.Web/locations/managedApis', parameters('location'), 'commondataservice')]"
+        },
+        "parameterValues": {
+          "token:clientId": "[parameters('clientId')]",
+          "token:clientSecret": "[parameters('clientSecret')]",
+          "token:tenantId": "[parameters('tenantId')]",
+          "token:grantType": "[variables('grantType')]"
+        }
+      }
+    }
+  ]
+}

--- a/scripts/modules/MsIndustryLinks/azureDeploymentPackage/eventhub/connection.json
+++ b/scripts/modules/MsIndustryLinks/azureDeploymentPackage/eventhub/connection.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Specifies the location in which the resources should be deployed."
+      }
+    }
+  },
+  "variables": {
+    "eventHubNamespaceName": "contosoindustrylinkeh",
+    "name": "eventhubs",
+    "displayName": "Azure Event Hubs Connection"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/connections",
+      "apiVersion": "2016-06-01",
+      "name": "[variables('name')]",
+      "location": "[parameters('location')]",
+      "properties": {
+        "displayName": "[variables('displayName')]",
+        "api": {
+          "id": "[subscriptionResourceId('Microsoft.Web/locations/managedApis', parameters('location'), 'eventhubs')]"
+        },
+        "parameterValueSet": {
+          "name": "managedIdentityAuth",
+          "values": {
+            "namespaceEndpoint": {
+              "value": "[format('sb://{0}.servicebus.windows.net', variables('eventHubNamespaceName'))]"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/scripts/modules/MsIndustryLinks/azureDeploymentPackage/eventhub/deploy.json
+++ b/scripts/modules/MsIndustryLinks/azureDeploymentPackage/eventhub/deploy.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Specifies the location in which the resources should be deployed."
+      }
+    },
+    "managedIdentityName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the user managed identity to assign to this resource."
+      }
+    }
+  },
+  "variables": {
+    "eventHubNamespaceName": "ContosoIndustryLinkEH",
+    "eventHubSku": "Standard",
+    "skuCapacity": 1,
+    "eventHubName": "myeventhubname",
+    "consumerGroupName": "$Default",
+    "roleDefinitionId": "f526a384-b230-433a-b45c-95f59c4a2dec",
+    "roleAssignmentDescription": "Contoso Industry Link event hub access"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.EventHub/namespaces",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[variables('eventHubNamespaceName')]",
+      "location": "[parameters('location')]",
+      "sku": {
+        "name": "[variables('eventHubSku')]",
+        "tier": "[variables('eventHubSku')]",
+        "capacity": "[variables('skuCapacity')]"
+      },
+      "tags": {},
+      "properties": {}
+    },
+    {
+      "type": "Microsoft.EventHub/namespaces/eventhubs",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[format('{0}/{1}', variables('eventHubNamespaceName'), variables('eventHubName'))]",
+      "properties": {},
+      "dependsOn": [
+        "[resourceId('Microsoft.EventHub/namespaces', variables('eventHubNamespaceName'))]"
+      ]
+    },
+    {
+      "condition": "[and(not(equals(variables('consumerGroupName'), '')), not(equals(variables('consumerGroupName'), '$Default')))]",
+      "type": "Microsoft.EventHub/namespaces/eventhubs/consumergroups",
+      "apiVersion": "2022-10-01-preview",
+      "name": "[format('{0}/{1}/{2}', variables('eventHubNamespaceName'), variables('eventHubName'), variables('consumerGroupName'))]",
+      "properties": {},
+      "dependsOn": [
+        "[resourceId('Microsoft.EventHub/namespaces/eventhubs', variables('eventHubNamespaceName'), variables('eventHubName'))]"
+      ]
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2020-04-01-preview",
+      "name": "[guid(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), resourceGroup().id, variables('roleDefinitionId'))]",
+      "properties": {
+        "description": "[variables('roleAssignmentDescription')]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')), '2018-11-30').principalId]",
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', variables('roleDefinitionId'))]",
+        "principalType": "ServicePrincipal"
+      }
+    }
+  ]
+}

--- a/scripts/modules/MsIndustryLinks/azureDeploymentPackage/logicApp/deploy.json
+++ b/scripts/modules/MsIndustryLinks/azureDeploymentPackage/logicApp/deploy.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Specifies the location in which the resources should be deployed."
+      }
+    },
+    "managedIdentityName": {
+      "type": "string",
+      "metadata": {
+        "description": "The name of the user managed identity to assign to this resource."
+      }
+    }
+  },
+  "variables": {
+    "name": "ContosoIndustryLink"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Logic/workflows",
+      "apiVersion": "2019-05-01",
+      "name": "[variables('name')]",
+      "location": "[parameters('location')]",
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')))]": {}
+        }
+      },
+      "properties": {
+        "state": "Enabled",
+        "definition": {
+          "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+          "contentVersion": "1.0.0.0",
+          "parameters": {},
+          "triggers": {},
+          "actions": {},
+          "outputs": {}
+        },
+        "parameters": {}
+      }
+    }
+  ]
+}

--- a/scripts/modules/MsIndustryLinks/templates/data_source/DataSourceWorkflow.psm1
+++ b/scripts/modules/MsIndustryLinks/templates/data_source/DataSourceWorkflow.psm1
@@ -349,7 +349,6 @@ function New-LogicAppDataSourceWorkflow {
     else {
         $apiName = Get-ApiName -DataSourceType $dataSourceType
         $apiId = Get-LogicAppApiId -DataSourceType $dataSourceType -ApiName $apiName
-        $dataSourceParameters | Add-Member -NotePropertyName 'organization_url' -NotePropertyValue @{value = "[parameters('organization_url')]" }
     }
 
     $dataSourceConnections = @{

--- a/scripts/modules/MsIndustryLinks/templates/data_source/DataSourceWorkflow.psm1
+++ b/scripts/modules/MsIndustryLinks/templates/data_source/DataSourceWorkflow.psm1
@@ -355,9 +355,10 @@ function New-LogicAppDataSourceWorkflow {
     $dataSourceConnections = @{
         value = @{
             $apiName = @{
-                connectionId   = "[resourceId('Microsoft.Web/connections', '$apiName')]"
-                connectionName = $apiName
-                id             = $apiId
+                connectionId         = "[resourceId('Microsoft.Web/connections', '$apiName')]"
+                connectionName       = $apiName
+                connectionProperties = Get-ConnectionProperties -DataSourceType $dataSourceType
+                id                   = $apiId
             }
         }
     }
@@ -522,7 +523,26 @@ function Get-LogicAppApiId {
     if ($dataSource -eq "customconnector" -and !($IsCustomConnectorCertified)) {
         return "[resourceId('Microsoft.Web/customApis', '$ApiName')]"
     }
-    return "[subscriptionResourceId('Microsoft.Web/locations/managedApis', location, '$apiName')]"
+    return "[subscriptionResourceId('Microsoft.Web/locations/managedApis', parameters('location'), '$apiName')]"
+}
+
+function Get-ConnectionProperties {
+    param (
+        [Parameter(Mandatory = $true, HelpMessage = "The data source type.")]
+        [string] $DataSourceType
+    )
+
+    $managedIdentitySources = @("azureblobstorage", "eventhub")
+    if ($DataSourceType.ToLower() -in $managedIdentitySources) {
+        return @{
+            authentication = @{
+                identity = "[format('{0}', resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', parameters('managedIdentityName')))]"
+                type     = "ManagedServiceIdentity"
+            }
+        }
+    }
+
+    return @{}
 }
 
 function Get-TransformDataSubflow {

--- a/scripts/modules/MsIndustryLinks/templates/data_source/dataverse/logicapp_dataverse.json
+++ b/scripts/modules/MsIndustryLinks/templates/data_source/dataverse/logicapp_dataverse.json
@@ -1,63 +1,62 @@
 {
-    "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
-    "contentVersion": "1.0.0.0",
-    "outputs": {},
-    "parameters": {
-      "$connections": {
-        "defaultValue": {},
-        "type": "Object"
-      },
-      "organization_url": {
-        "defaultValue": "",
-        "type": "String"
-      },
-      "plural_table_name": {
-        "defaultValue": "",
-        "type": "String"
-      }
+  "$schema": "https://schema.management.azure.com/providers/Microsoft.Logic/schemas/2016-06-01/workflowdefinition.json#",
+  "contentVersion": "1.0.0.0",
+  "outputs": {},
+  "parameters": {
+    "$connections": {
+      "defaultValue": {},
+      "type": "Object"
     },
-    "triggers": {
-      "manual": {
-        "inputs": {},
-        "kind": "Http",
-        "type": "Request"
-      }
+    "organization_url": {
+      "defaultValue": "[parameters('organizationUrl')]",
+      "type": "String"
     },
-    "actions": {
-      "Retrieve_data_from_Dataverse": {
-        "inputs": {
-          "headers": {
-            "organization": "@parameters('organization_url')",
-            "prefer": "odata.include-annotations=*"
-          },
-          "host": {
-            "connection": {
-                "name": "@parameters('$connections')['commondataservice']['connectionId']"
-            }
-          },
-          "method": "get",
-          "path": "/api/data/v9.1/@{encodeURIComponent(encodeURIComponent(parameters('plural_table_name')))}"
+    "plural_table_name": {
+      "defaultValue": "",
+      "type": "String"
+    }
+  },
+  "triggers": {
+    "manual": {
+      "inputs": {},
+      "kind": "Http",
+      "type": "Request"
+    }
+  },
+  "actions": {
+    "Retrieve_data_from_Dataverse": {
+      "inputs": {
+        "headers": {
+          "organization": "@parameters('organization_url')",
+          "prefer": "odata.include-annotations=*"
         },
-        "runAfter": {},
-        "type": "ApiConnection"
-      },
-      "Ingest_data_subflow": {
-        "runAfter": {
-          "Retrieve_data_from_Dataverse": ["Succeeded"]
-        },
-        "type": "Workflow",
-        "inputs": {
-          "host": {
-            "triggerName": "manual",
-            "workflow": {
-              "id": "[resourceId('Microsoft.Logic/workflows', 'ContosoIndustryLink_Sink')]"
-            }
-          },
-          "body": {
-            "payload": "@body('Retrieve_data_from_Dataverse')?['value']"
+        "host": {
+          "connection": {
+            "name": "@parameters('$connections')['commondataservice']['connectionId']"
           }
+        },
+        "method": "get",
+        "path": "/api/data/v9.1/@{encodeURIComponent(encodeURIComponent(parameters('plural_table_name')))}"
+      },
+      "runAfter": {},
+      "type": "ApiConnection"
+    },
+    "Ingest_data_subflow": {
+      "runAfter": {
+        "Retrieve_data_from_Dataverse": ["Succeeded"]
+      },
+      "type": "Workflow",
+      "inputs": {
+        "host": {
+          "triggerName": "manual",
+          "workflow": {
+            "id": "[resourceId('Microsoft.Logic/workflows', 'ContosoIndustryLink_Sink')]"
+          }
+        },
+        "body": {
+          "payload": "@body('Retrieve_data_from_Dataverse')?['value']"
         }
       }
     }
   }
-  
+}

--- a/scripts/modules/MsIndustryLinks/templates/flow_workflow.json.tmpl
+++ b/scripts/modules/MsIndustryLinks/templates/flow_workflow.json.tmpl
@@ -33,9 +33,9 @@
       // (entityName) to know which table to retrieve
       // data from.
       "entityName": "contoso_transactions",
-      "$select": "",      // optional: comma-separated list of column unique names to limit which columns are returned
-      "$filter": "",      // optional: OData style filter expression to limit which rows are returned
-      "$orderby": ""       // optional: Columns to sort by in OData orderBy style (excluding lookups)
+      "$select": "", // optional: comma-separated list of column unique names to limit which columns are returned
+      "$filter": "", // optional: OData style filter expression to limit which rows are returned
+      "$orderby": "", // optional: Columns to sort by in OData orderBy style (excluding lookups)
 
       // Event Hubs requires the event hub name,
       // consumer group, content type and maximum
@@ -71,7 +71,6 @@
     // This can include parameters to a custom
     // connector data sink with an array as input.
     "parameters": {
-
       ///--- DATAVERSE ONLY ---///
       "plural_table_name": {
         "value": "contoso_transactions"
@@ -99,7 +98,7 @@
       // Remap the input data into the format required by the API.
       // Example: Custom connector accepting a single object as input
       "body/customer_id": "@items('For_each_item')?['contoso_customerid']",
-      "body/timestamp": "@items('For_each_item')?['contoso_timestamp']"
+      "body/timestamp": "@items('For_each_item')?['contoso_timestamp']",
 
       // Example: Custom connector accepting an array of objects as input
       "customer_id": "@item()?['contoso_customerid']",
@@ -121,8 +120,8 @@
     "isCertified": false,
     "inputType": "", // custom connector parameter input type. Options: Array, Object
     "connection": {
-      "connectorId": "",  // required for non-certified custom connectors only
-      "apiName": "",      // required for certified custom connectors only
+      "connectorId": "", // required for non-certified custom connectors only
+      "apiName": "", // required for certified custom connectors only
       "operationId": ""
     }
   }

--- a/scripts/modules/MsIndustryLinks/templates/ingest/IngestionWorkflow.psm1
+++ b/scripts/modules/MsIndustryLinks/templates/ingest/IngestionWorkflow.psm1
@@ -90,15 +90,11 @@ function New-LogicAppIngestionWorkflow {
         "customconnector" {
             $apiName = $DataSinkConfig.properties.name
             $apiId = Get-LogicAppApiId -DataSourceType $dataSinkType -ApiName $apiName -IsCustomConnectorCertified $DataSinkConfig.isCertified
-
             Set-LogicAppCustomConnectorDataSinkConfiguration -DataSinkConfig $DataSinkConfig -Definition $definition | Out-Null
         }
         "dataverse" {
             $apiName = Get-ApiName -DataSourceType $dataSinkType
             $apiId = Get-LogicAppApiId -DataSourceType $dataSinkType -ApiName $apiName
-
-            $DataSinkConfig.parameters | Add-Member -NotePropertyName 'organization_url' -NotePropertyValue @{value = "[parameters('organization_url')]" }
-
             $definition.actions.For_each_item.actions.Ingest_record.inputs.body = $DataSinkConfig.mapping
         }
         default {

--- a/scripts/modules/MsIndustryLinks/templates/ingest/dataverse/logicapp_dataverse_insert.json
+++ b/scripts/modules/MsIndustryLinks/templates/ingest/dataverse/logicapp_dataverse_insert.json
@@ -7,7 +7,7 @@
       "type": "Object"
     },
     "organization_url": {
-      "defaultValue": "",
+      "defaultValue": "[parameters('organizationUrl')]",
       "type": "String"
     },
     "plural_table_name": {

--- a/scripts/modules/MsIndustryLinks/templates/ingest/dataverse/logicapp_dataverse_upsert.json
+++ b/scripts/modules/MsIndustryLinks/templates/ingest/dataverse/logicapp_dataverse_upsert.json
@@ -7,7 +7,7 @@
       "type": "Object"
     },
     "organization_url": {
-      "defaultValue": "",
+      "defaultValue": "[parameters('organizationUrl')]",
       "type": "String"
     },
     "plural_table_name": {

--- a/scripts/modules/MsIndustryLinks/templates/logicapp_workflow.json.tmpl
+++ b/scripts/modules/MsIndustryLinks/templates/logicapp_workflow.json.tmpl
@@ -22,13 +22,12 @@
 
     // Parameters required by the data source.
     "parameters": {
-
       // Dataverse requires the plural table name
       // (plural_table_name) to know which table to
       // retrieve the data from.
       "plural_table_name": {
         "value": "contoso_transactions"
-      }
+      },
 
       // Azure Blob Storage requires the storage
       // account and container to check for data files.
@@ -66,7 +65,7 @@
     // This can be used to manipulate data
     // coming back from Dataverse using
     // queries such as $filter, $select, $top etc
-    "queries": {}
+    "queries": {},
 
     ///--- CUSTOM CONNECTORS ONLY ---///
     "isCertified": false,
@@ -90,7 +89,6 @@
     "upsert": false, // Dataverse only
 
     "parameters": {
-
       ///--- DATAVERSE ONLY ---///
       "plural_table_name": {
         "value": "contoso_transactions"
@@ -123,11 +121,11 @@
       // Remap the input data into the format required by the API.
       // Example: Custom connector accepting a single object as input
       "body/customer_id": "@items('For_each_item')?['contoso_customerid']",
-      "body/timestamp": "@items('For_each_item')?['contoso_timestamp']"
+      "body/timestamp": "@items('For_each_item')?['contoso_timestamp']",
 
       // Example: Custom connector accepting an array of objects as input
       "customer_id": "@item()?['contoso_customerid']",
-      "timestamp": "@item()?['contoso_timestamp']"
+      "timestamp": "@item()?['contoso_timestamp']",
 
       ///--- DATAVERSE ONLY ---///
       // record's GUID, insert only. Leave out to autogenerate GUID.


### PR DESCRIPTION
Add cmdlet to generate ARM templates for Logic App industry link. Added and updated documentation on usage. Bug fixes in logic app templates.

Supported data sources:
- Azure Blob Storage
- Azure Event Hubs
- Dataverse

Supported data sinks:
- Dataverse

To be added in separate PR:
- Custom Connector