### PR TITLE
Fix PSScriptAnalyzer warnings in templates folder

### DIFF
--- a/scripts/modules/MsIndustryLinks/templates/data_transform/TransformationWorkflow.psm1
+++ b/scripts/modules/MsIndustryLinks/templates/data_transform/TransformationWorkflow.psm1
@@ -28,6 +28,8 @@
     New-TransformWorkflow -WorkflowConfigFile workflow.json -OutputDirectory output
 #>
 function New-TransformWorkflow {
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([System.Collections.Hashtable])]
     param (
         [Parameter(Mandatory = $true, HelpMessage = "The path to the workflow configuration JSON file.")]
         [string] $WorkflowConfigFile,


### PR DESCRIPTION
Fix PSScriptAnalyzer warnings in templates folder including PSUseOutputTypeCorrectly, PSUseShouldProcessForStateChangingFunctions, and PSUseSingularNouns.